### PR TITLE
COMP: Fix -Winconsistent-missing-override warnings

### DIFF
--- a/AutoPortPlacement/Logic/vtkSlicerAutoPortPlacementLogic.h
+++ b/AutoPortPlacement/Logic/vtkSlicerAutoPortPlacementLogic.h
@@ -51,7 +51,7 @@ public:
 
   static vtkSlicerAutoPortPlacementLogic *New();
   vtkTypeMacro(vtkSlicerAutoPortPlacementLogic, vtkSlicerModuleLogic);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   // For setting the rotation values of each joint in the robot's arm
   void SetPassiveLeftJoint(unsigned jointIdx, double value);
@@ -94,14 +94,14 @@ public:
 
 protected:
   vtkSlicerAutoPortPlacementLogic();
-  virtual ~vtkSlicerAutoPortPlacementLogic();
+  ~vtkSlicerAutoPortPlacementLogic() override;
 
-  virtual void SetMRMLSceneInternal(vtkMRMLScene* newScene);
+  void SetMRMLSceneInternal(vtkMRMLScene* newScene) override;
   /// Register MRML Node classes to Scene. Gets called automatically when the MRMLScene is attached to this logic class.
-  virtual void RegisterNodes();
-  virtual void UpdateFromMRMLScene();
-  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node);
-  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node);
+  void RegisterNodes() override;
+  void UpdateFromMRMLScene() override;
+  void OnMRMLSceneNodeAdded(vtkMRMLNode* node) override;
+  void OnMRMLSceneNodeRemoved(vtkMRMLNode* node) override;
 private:
 
   vtkSlicerAutoPortPlacementLogic(const vtkSlicerAutoPortPlacementLogic&); // Not implemented

--- a/AutoPortPlacement/qSlicerAutoPortPlacementModule.h
+++ b/AutoPortPlacement/qSlicerAutoPortPlacementModule.h
@@ -38,29 +38,29 @@ public:
 
   typedef qSlicerLoadableModule Superclass;
   explicit qSlicerAutoPortPlacementModule(QObject *parent=0);
-  virtual ~qSlicerAutoPortPlacementModule();
+  ~qSlicerAutoPortPlacementModule() override;
 
   qSlicerGetTitleMacro(QTMODULE_TITLE);
 
-  virtual QString helpText()const;
-  virtual QString acknowledgementText()const;
-  virtual QStringList contributors()const;
+  QString helpText()const override;
+  QString acknowledgementText()const override;
+  QStringList contributors()const override;
 
-  virtual QIcon icon()const;
+  QIcon icon()const override;
 
-  virtual QStringList categories()const;
-  virtual QStringList dependencies() const;
+  QStringList categories()const override;
+  QStringList dependencies() const override;
 
 protected:
 
   /// Initialize the module. Register the volumes reader/writer
-  virtual void setup();
+  void setup() override;
 
   /// Create and return the widget representation associated to this module
-  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation();
+  qSlicerAbstractModuleRepresentation * createWidgetRepresentation() override;
 
   /// Create and return the logic associated to this module
-  virtual vtkMRMLAbstractLogic* createLogic();
+  vtkMRMLAbstractLogic* createLogic() override;
 
 protected:
   QScopedPointer<qSlicerAutoPortPlacementModulePrivate> d_ptr;

--- a/AutoPortPlacement/qSlicerAutoPortPlacementModuleWidget.h
+++ b/AutoPortPlacement/qSlicerAutoPortPlacementModuleWidget.h
@@ -36,7 +36,7 @@ public:
 
   typedef qSlicerAbstractModuleWidget Superclass;
   qSlicerAutoPortPlacementModuleWidget(QWidget *parent=0);
-  virtual ~qSlicerAutoPortPlacementModuleWidget();
+  ~qSlicerAutoPortPlacementModuleWidget() override;
 
   // If robot configuration is changed programmatically, have sliders
   // reflect change
@@ -55,7 +55,7 @@ public slots:
 protected:
   QScopedPointer<qSlicerAutoPortPlacementModuleWidgetPrivate> d_ptr;
 
-  virtual void setup();
+  void setup() override;
 
 private:
   Q_DECLARE_PRIVATE(qSlicerAutoPortPlacementModuleWidget);


### PR DESCRIPTION
Fix warnings like the following:

```
/path/to/PortPlacement/AutoPortPlacement/Logic/vtkSlicerAutoPortPlacementLogic.h:104:16: warning: 'OnMRMLSceneNodeRemoved' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node);
               ^
```